### PR TITLE
Remove duplicate entries from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,11 +7,9 @@ setup(
     author='NuoDB',
     author_email='info@nuodb.com',
     description='NuoDB Python driver',
-    license='BSD',
     keywords='scalable cloud database',
     packages=['pynuodb', 'tests'],
     url='https://github.com/nuodb/nuodb-python',
     license='BSD licence, see LICENCE.txt',
-    description='NuoDB Python Driver',
     long_description=open('README.md').read()
 )


### PR DESCRIPTION
The presence of duplicate entires causes error when trying to run setup.py
