### PR TITLE
Fix _takeBytes bounds check

### DIFF
--- a/pynuodb/encodedsession.py
+++ b/pynuodb/encodedsession.py
@@ -80,8 +80,11 @@ class EncodedSession(Session):
         self.doConnect()
 
         self.__output = None
+        """ @type : str """
         self.__input = None
+        """ @type : str """
         self.__inpos = 0
+        """ @type : int """
         self.closed = False
 
     # Mostly for connections
@@ -800,7 +803,7 @@ class EncodedSession(Session):
 
     def _takeBytes(self, length):
         """Gets the next length of bytes off the session."""
-        if self.__inpos >= len(self.__input):
+        if self.__inpos + length > len(self.__input):
             raise EndOfStream('end of stream reached')
                         
         try:


### PR DESCRIPTION
A response from the server that ended with a zero length string would result in an error like:

```
  File "/Users/jgetto/cm/nuo3rdparty/common/nuodb-python/pynuodb/cursor.py", line 184, in fetchall
    row = self.fetchone()
  File "/Users/jgetto/cm/nuo3rdparty/common/nuodb-python/pynuodb/cursor.py", line 157, in fetchone
    return self._result_set.fetchone(self.session)
  File "/Users/jgetto/cm/nuo3rdparty/common/nuodb-python/pynuodb/result_set.py", line 31, in fetchone
    session.fetch_result_set_next(self)
  File "/Users/jgetto/cm/nuo3rdparty/common/nuodb-python/pynuodb/encodedsession.py", line 298, in fetch_result_set_next
    row[i] = self.getValue()
  File "/Users/jgetto/cm/nuo3rdparty/common/nuodb-python/pynuodb/encodedsession.py", line 731, in getValue
    return self.getString()
  File "/Users/jgetto/cm/nuo3rdparty/common/nuodb-python/pynuodb/encodedsession.py", line 561, in getString
    return self._takeBytes(typeCode - 109)
  File "/Users/jgetto/cm/nuo3rdparty/common/nuodb-python/pynuodb/encodedsession.py", line 804, in _takeBytes
    raise EndOfStream('end of stream reached')
```

This is because `self.__inpos == len(self.input)`, so the initial check would fail, even though length was zero. The new check doesn't have exactly the same contract, but I think it is safer. Previously if `self.__inpos == 0`, and `len(self.input) == 10`, `_takeBytes(20)` would succeed, but only return 10 bytes. Now that call would fail.

If for some reason we want to keep the existing behavior this could also be fixed by checking if `length==0` and immediately returning `''`.
