### PR TITLE
Handle Unicode values in putString()

### DIFF
--- a/pynuodb/encodedsession.py
+++ b/pynuodb/encodedsession.py
@@ -387,10 +387,10 @@ class EncodedSession(Session):
         """
         length = len(value)
         if length < 40:
-            packed = chr(protocol.UTF8LEN0 + length) + value
+            packed = chr(protocol.UTF8LEN0 + length) + str(value)
         else:
             lengthStr = toByteString(length)
-            packed = chr(protocol.UTF8COUNT1 - 1 + len(lengthStr)) + lengthStr + value
+            packed = chr(protocol.UTF8COUNT1 - 1 + len(lengthStr)) + lengthStr + str(value)
         self.__output += packed
         return self
 


### PR DESCRIPTION
The "value" passed to putString() is often unicode. Trying to concat unicode and strings can result in:

  File "/Library/Python/2.7/site-packages/pynuodb/encodedsession.py", line 397, in putString
    packed = chr(protocol.UTF8COUNT1 - 1 + len(lengthStr)) + lengthStr + value
UnicodeDecodeError: 'ascii' codec can't decode byte 0x90 in position 1: ordinal not in range(128)

cast value to string to solve this.