### PR TITLE
Add column type to error message

### DIFF
--- a/pynuodb/datatype.py
+++ b/pynuodb/datatype.py
@@ -177,5 +177,5 @@ def TypeObjectFromNuodb(nuodb_type_name):
         return BINARY
 
     else:
-        raise DataError('received unknown column type from the database')
+        raise DataError('received unknown column type (%s) from the database' % nuodb_type_name)
 


### PR DESCRIPTION
To debug driver problems add the type of the column to the unknown column type
