### PR TITLE
Fix issues #41 and #42

### DIFF
--- a/pynuodb/exception.py
+++ b/pynuodb/exception.py
@@ -2,7 +2,7 @@
 
 import protocol
 
-__all__ = ['Warning', 'Error', 'InterfaceError', 'DatabaseError', 'DataError',
+__all__ = ['Warning', 'Error', 'InterfaceError', 'DatabaseError', 'BatchError', 'DataError',
            'OperationalError', 'IntegrityError', 'InternalError',
            'ProgrammingError', 'NotSupportedError', 'EndOfStream', 'db_error_handler']
 
@@ -32,6 +32,11 @@ class DatabaseError(Error):
     def __init__(self, value):
         Error.__init__(self, value)
 
+class BatchError(DatabaseError):
+    results = None
+    def __init__(self, value, results):
+        Error.__init__(self, value)
+        self.results = results
 
 class DataError(DatabaseError):
     def __init__(self, value):


### PR DESCRIPTION
This fix resets the cursor output buffer on each _putMessageId so that we don't get issues when a command raises an exception halfway through building message.   It also implements complete batch result reading instead of throwing at first error and provides a mechanism to get result update counts similar to JDBC.   This was whipped together pretty fast and isn't of immediate need, consider it a cursory review.   I just wanted to use python to fully test server side changes to executePreparedBatch implementation I can now do.   Would love to just hand it off if possible.
