### PR TITLE
Changing entity code to get LiveStatus attribute from a description

### DIFF
--- a/pynuodb/entity.py
+++ b/pynuodb/entity.py
@@ -1253,7 +1253,12 @@ class Description:
         if status_element is not None:
             status = status_element.text
 
-        return Description(name, template_name, variables, status)
+        live_status = ""
+        live_status_element = root.find("LiveStatus")
+        if live_status_element is not None:
+            live_status = live_status_element.text
+
+        return Description(name, template_name, variables, status, live_status)
 
     @staticmethod
     def from_list_message(message):
@@ -1264,17 +1269,19 @@ class Description:
 
         return names
 
-    def __init__(self, name, template_name, variables, status):
+    def __init__(self, name, template_name, variables, status, live_status=""):
         """
         @type name str
         @type template_name str
         @type variables dict[str,str]
         @type status str
+        @type live_status str
         """
         self._name = name
         self._template_name = template_name
         self._variables = variables
         self._status = status
+        self._live_status = live_status
 
     @property
     def name(self):
@@ -1291,3 +1298,7 @@ class Description:
     @property
     def status(self):
         return self._status
+
+    @property
+    def live_status(self):
+        return self._live_status


### PR DESCRIPTION
Adding live status attribute to Description object. LiveStatus is a new attribute of description messages that's specifically for the MET/UNMET status of a description and its values can be STOPPED, STARTED, ERROR, MET. The Status attribute now is specific to the status in the durable config used during enforcement, and is now limited to STOPPED and STARTED. The live_status parameter in the Description constructor is optional to not break compatibility.