### PR TITLE
Changing mock_tzs to use /etc/localtime if /etc/timezone doesn't exist

### DIFF
--- a/tests/mock_tzs.py
+++ b/tests/mock_tzs.py
@@ -4,12 +4,19 @@
 from datetime import timedelta
 from datetime import tzinfo
 from datetime import datetime
+import os
 
 import pytz
 
 import pynuodb
 
-Local = pytz.timezone(open('/etc/timezone').read().strip())
+if os.path.exists('/etc/timezone'):
+    with open('/etc/timezone') as file_:
+        Local = pytz.timezone(file_.read().strip())
+else:
+    with open('/etc/localtime', 'rb') as file_:
+        Local = pytz.build_tzinfo('localtime', file_)
+
 UTC = pytz.timezone('UTC')
 
 class _MyOffset(tzinfo):


### PR DESCRIPTION
This is just so that the tests can run without a ton of import errors on distributions that don't have /etc/timezone. These import errors are preventing whole test suites from running.