### PR TITLE
Preserve sign, exp, and int for decimal.Decimal results.

### DIFF
--- a/pynuodb/encodedsession.py
+++ b/pynuodb/encodedsession.py
@@ -566,7 +566,10 @@ class EncodedSession(Session):
         if typeCode in range(protocol.SCALEDLEN0, protocol.SCALEDLEN8 + 1):
             scale = fromByteString(self._takeBytes(1))
             value = fromSignedByteString(self._takeBytes(typeCode - 60))
-            return decimal.Decimal(value) / decimal.Decimal(10**scale)
+            # preserves Decimal sign, exp, int...
+            sign = 1 if value < 0 else 0
+            value = tuple(int(i) for i in str(abs(value)))
+            return decimal.Decimal((sign, value, -1 * scale))
 
         raise DataError('Not a scaled integer')
 

--- a/tests/nuodb_basic_test.py
+++ b/tests/nuodb_basic_test.py
@@ -156,6 +156,7 @@ class NuoDBBasicTest(NuoBase):
     #
     #   py.test -k "test_many_significant_digits"
     #
+    @unittest.skip("produces invalid UTF-8 code sequence")
     def test_many_significant_digits(self):
         self._test_decimal_fixture(decimal.Decimal("31943874831932418390.01"), 38, 12)
 

--- a/tests/nuodb_basic_test.py
+++ b/tests/nuodb_basic_test.py
@@ -130,6 +130,47 @@ class NuoDBBasicTest(NuoBase):
             finally:
                 con.close()
 
+    def _test_decimal_fixture(self, value, precision, scale):
+        con = self._connect()
+        cursor = con.cursor()
+        cursor.execute("DROP TABLE CASCADE t IF EXISTS")
+        try:
+            cursor.execute("CREATE TABLE t (x NUMERIC(%s,%s))" % (precision, scale))
+            cursor.execute("INSERT INTO t (x) VALUES (?)", (value,))
+            cursor.execute("SELECT * FROM t")
+            row = cursor.fetchone()
+            self.assertEqual(row[0], value)
+            self.assertEqual(str(row[0]), str(value))
+        finally:
+            try:
+                cursor.execute("DROP TABLE t IF EXISTS")
+            finally:
+                con.close()
+
+    # This test demonstrates the broken implementation of putScaledInt
+    # which results in:
+    #
+    #   DataError: 'INVALID_UTF8: invalid UTF-8 code sequence'
+    #
+    # Run separately via:
+    #
+    #   py.test -k "test_many_significant_digits"
+    #
+    def test_many_significant_digits(self):
+        self._test_decimal_fixture(decimal.Decimal("31943874831932418390.01"), 38, 12)
+
+    # This test demonstrates the broken implementation of getScaledInt
+    # which results in:
+    #
+    #   "1" instead of "1.000"
+    #
+    # Run separately via:
+    #
+    #   py.test -k "test_numeric_no_decimal"
+    #
+    def test_numeric_no_decimal(self):
+        self._test_decimal_fixture(decimal.Decimal("1.000"), 5, 3)
+
     def test_param_numeric_types_neg(self):
         con = self._connect()
         cursor = con.cursor()


### PR DESCRIPTION
This is for PB who uses SQLAlchemy, Flask, and Sandman. This resolves one of the SQLAlchemy compliance test suite bugs against NuoDB. In a nutshell, we successfully store 1.000 and the encoded session returns the value, but on decoding we lose information, namely we lose the exp information. Net net, the result seen in the client is "1" rather than "1.000". This fix produces the latter so there is no loss of information round trip with NuoDB.