### PR TITLE
Stress tests, getValue policy optimization and README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ NuoDB - Python
 
 [![Build Status](https://travis-ci.org/nuodb/nuodb-python.png?branch=master)](https://travis-ci.org/nuodb/nuodb-python)
 
-This is the official Python package for [NuoDB](http://www.nuodb.com).
+This is the official Python package for [NuoDB](http://www.nuodb.com). Compliant with [PEP 249](https://www.python.org/dev/peps/pep-0249/) standard for Python database APIs.
 
 ### Requirements
 

--- a/pynuodb/encodedsession.py
+++ b/pynuodb/encodedsession.py
@@ -719,9 +719,19 @@ class EncodedSession(Session):
         """
         typeCode = self._peekTypeCode()
         
-        # get null type
-        if typeCode is protocol.NULL:
-            return self.getNull()
+
+        # get string type
+        if typeCode in range(protocol.UTF8COUNT1, protocol.UTF8COUNT4 + 1) or \
+             typeCode in range(protocol.UTF8LEN0, protocol.UTF8LEN39 + 1):
+            return self.getString()
+
+        # get integer type
+        elif typeCode in range(protocol.INTMINUS10, protocol.INTLEN8 + 1):
+            return self.getInt()
+
+        # get double precision type
+        elif typeCode in range(protocol.DOUBLELEN0, protocol.DOUBLELEN8 + 1):
+            return self.getDouble()
         
         # get boolean type
         elif typeCode in [protocol.TRUE, protocol.FALSE]:
@@ -731,22 +741,9 @@ class EncodedSession(Session):
         elif typeCode in [protocol.UUID, protocol.SCALEDCOUNT1, protocol.SCALEDCOUNT2]:
             return self.getUUID()
         
-        # get integer type
-        elif typeCode in range(protocol.INTMINUS10, protocol.INTLEN8 + 1):
-            return self.getInt()
-        
         # get scaled int type
         elif typeCode in range(protocol.SCALEDLEN0, protocol.SCALEDLEN8 + 1):
             return self.getScaledInt()
-        
-        # get double precision type
-        elif typeCode in range(protocol.DOUBLELEN0, protocol.DOUBLELEN8 + 1):
-            return self.getDouble()
-        
-        # get string type
-        elif typeCode in range(protocol.UTF8COUNT1, protocol.UTF8COUNT4 + 1) or \
-             typeCode in range(protocol.UTF8LEN0, protocol.UTF8LEN39 + 1):
-            return self.getString()
         
         # get opaque type
         elif typeCode in range(protocol.OPAQUECOUNT1, protocol.OPAQUECOUNT4 + 1) or \
@@ -773,6 +770,10 @@ class EncodedSession(Session):
         elif typeCode in range(protocol.SCALEDDATELEN1, protocol.SCALEDDATELEN8 + 1):
             return self.getScaledDate()
         
+        # get null type
+        elif typeCode is protocol.NULL:
+            return self.getNull()
+
         else:
             raise NotImplementedError("not implemented")
 

--- a/tests/nuodb_stress_test.py
+++ b/tests/nuodb_stress_test.py
@@ -1,0 +1,42 @@
+import pynuodb.util
+import unittest
+import sys
+
+from nuodb_base import NuoBase
+
+HOST            = "localhost"
+DOMAIN_USER     = "domain"
+DOMAIN_PASSWORD = "bird"
+
+DBA_USER        = 'dba'
+DBA_PASSWORD    = 'dba_password'
+DATABASE_NAME   = 'pynuodb_test'
+
+class NuoDBStressTest(NuoBase):
+
+	def test_million_reads(self):
+		connection = pynuodb.connect(DATABASE_NAME, HOST, DBA_USER, DBA_PASSWORD, options={'schema':'hockey'})
+		cursor = connection.cursor()
+		alphabet = "abcdefghijklmnopqrstuwxyz"
+
+		cursor.execute("USE test")
+		cursor.execute("DROP TABLE hundred IF EXISTS")
+		cursor.execute("CREATE TABLE hundred (f1 INTEGER)")
+
+		for i in range(100):
+			cursor.execute("INSERT INTO hundred VALUES (?)", [i])
+		connection.commit();
+
+		cursor.execute("SELECT ? FROM hundred AS a1, hundred AS a2, hundred AS a3", [ alphabet ])
+
+		#Fetch the next 1,000,000 results 
+		for i in xrange(1000000):
+			rowArray = cursor.fetchone()
+
+		cursor.close()
+		connection.close()
+
+	def test_hundred_connection(self):
+		for i in range(0, 1000):
+			connection = pynuodb.connect(DATABASE_NAME, HOST, DBA_USER, DBA_PASSWORD, options={'schema':'hockey'})
+			connection.close()


### PR DESCRIPTION
Added 2 new tests to the testing harness 
- Connect 1000 times to the database
- Process 1,000,000 rows from the database

By running these tests using cProfile I determined that a re-ordering of the getValue if / elif block can save time. This new policy first checks most common datatypes such as String, Int, Double.

Before policy in get Value
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
  2010973    6.398    0.000   17.808    0.000 encodedsession.py:716(getValue)
```
After policy
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   2010973    4.284    0.000   14.684    0.000 encodedsession.py:716(getValue)
```
Updated README to reflect PEP 249 compliance 