### PR TITLE
Relative imports and fix unit test.

### DIFF
--- a/pynuodb/connection.py
+++ b/pynuodb/connection.py
@@ -9,10 +9,10 @@ connect -- Creates a connection object.
 
 __all__ = [ 'apilevel', 'threadsafety', 'paramstyle', 'connect', 'Connection' ]
 
-from cursor import Cursor
-from encodedsession import EncodedSession
-from crypt import ClientPassword, RC4Cipher
-from util import getCloudEntry
+from .cursor import Cursor
+from .encodedsession import EncodedSession
+from .crypt import ClientPassword, RC4Cipher
+from .util import getCloudEntry
 
 import time
 import string
@@ -63,7 +63,7 @@ class Connection(object):
     auto_commit (setter) -- Sets the value of auto_commit on the database.
     """
 
-    from exception import Warning, Error, InterfaceError, DatabaseError, DataError, \
+    from .exception import Warning, Error, InterfaceError, DatabaseError, DataError, \
             OperationalError, IntegrityError, InternalError, \
             ProgrammingError, NotSupportedError
     

--- a/pynuodb/cursor.py
+++ b/pynuodb/cursor.py
@@ -8,8 +8,8 @@ Cursor -- Class for representing a database cursor.
 
 from collections import deque
 
-from statement import Statement, PreparedStatement
-from exception import Error, NotSupportedError, ProgrammingError
+from .statement import Statement, PreparedStatement
+from .exception import Error, NotSupportedError, ProgrammingError
 
 
 class Cursor(object):

--- a/pynuodb/datatype.py
+++ b/pynuodb/datatype.py
@@ -26,7 +26,7 @@ __all__ = [ 'Date', 'Time', 'Timestamp', 'DateFromTicks', 'TimeFromTicks',
 
 from datetime import datetime as Timestamp, date as Date, time as Time, timedelta as TimeDelta
 import decimal, time
-from exception import DataError
+from .exception import DataError
 
 class Binary(object):
     

--- a/pynuodb/encodedsession.py
+++ b/pynuodb/encodedsession.py
@@ -6,24 +6,20 @@ EncodedSession -- Class for representing an encoded session with the database.
 
 __all__  = [ 'EncodedSession' ]
 
-from .crypt import toByteString, fromByteString, toSignedByteString, fromSignedByteString
-from .session import Session, SessionException
-
 import uuid
 import struct
+import decimal
+
+from .crypt import toByteString, fromByteString, toSignedByteString, fromSignedByteString
+from .session import Session, SessionException
 from . import protocol
 from . import datatype
-import decimal
-import sys
-
 from .exception import DataError, EndOfStream, ProgrammingError, db_error_handler, BatchError
 from .datatype import TypeObjectFromNuodb
-
 from .statement import Statement, PreparedStatement, ExecutionResult
 from .result_set import ResultSet
 
 class EncodedSession(Session):
-
     """Class for representing an encoded session with the database.
     
     Public Functions:

--- a/pynuodb/entity.py
+++ b/pynuodb/entity.py
@@ -40,8 +40,8 @@ to another broker. Either this should be added, or some clear exception
 should be raised to help the caller make this happen.
 """
 
-from session import BaseListener, Session, SessionMonitor, SessionException
-from util import DatabaseAction, startProcess, killProcess, doDatabaseAction, queryEngine
+from .session import BaseListener, Session, SessionMonitor, SessionException
+from .util import DatabaseAction, startProcess, killProcess, doDatabaseAction, queryEngine
 
 import time, json, socket
 from threading import Event, Lock

--- a/pynuodb/exception.py
+++ b/pynuodb/exception.py
@@ -1,8 +1,6 @@
 """Classes containing the exceptions for reporting errors."""
 
 from . import protocol
-import sys
-import traceback
 
 __all__ = ['Warning', 'Error', 'InterfaceError', 'DatabaseError', 'BatchError', 'DataError',
            'OperationalError', 'IntegrityError', 'InternalError',
@@ -34,11 +32,14 @@ class DatabaseError(Error):
     def __init__(self, value):
         Error.__init__(self, value)
 
+
 class BatchError(DatabaseError):
     results = None
+
     def __init__(self, value, results):
         Error.__init__(self, value)
         self.results = results
+
 
 class DataError(DatabaseError):
     def __init__(self, value):
@@ -63,6 +64,7 @@ class InternalError(DatabaseError):
 class ProgrammingError(DatabaseError):
     def __init__(self, value):
         DatabaseError.__init__(self, value)
+
 
 class NotSupportedError(DatabaseError):
     def __init__(self, value):

--- a/pynuodb/util.py
+++ b/pynuodb/util.py
@@ -32,7 +32,7 @@ __all__ = [ "DatabaseAction", "EngineMonitor",
 # to monitor (for now, see Platform/Log.h for the values). There should also
 # be a utility listener that parses the stat/log XML and pretty-prints it.
 
-from session import Session, SessionMonitor, SessionException, checkForError, BaseListener
+from .session import Session, SessionMonitor, SessionException, checkForError, BaseListener
 
 from xml.etree import ElementTree
 

--- a/tests/nuodb_entity_test.py
+++ b/tests/nuodb_entity_test.py
@@ -369,14 +369,15 @@ class NuoDBEntityTest(unittest.TestCase):
     def _cleanup(self, domain):
         if domain is not None:
             try:
-                db_names = [db.name for db in domain.databases]
+                db_names = [TEST_DB_NAME, TEST_DB_NAME2]
                 for name in db_names:
                     db = domain.get_database(name)
-                    db.shutdown()
-                    i = 0
-                    while len(db.processes) > 0 and i < 10:
-                        time.sleep(1)
-                        i += 1
+                    if db is not None:
+                        db.shutdown()
+                        i = 0
+                        while len(db.processes) > 0 and i < 10:
+                            time.sleep(1)
+                            i += 1
                     if domain.get_database(name) is not None:
                         raise Exception("Could not shutdown existing test database %s" % (name))
 


### PR DESCRIPTION
Standard relative imports to avoid possible conflicts with other libraries, and fix the entity test so it does not try to shutdown all databases, only the databases it used.

This fixes: https://github.com/nuodb/nuodb-python/issues/77