### PR TITLE
Updated README with live wiki link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ or using variables::
     print cursor.fetchone()
 
 For further information on getting started with NuoDB, please refer to the
-`NuoDB wiki <http://doc.nuodb.com/display/DOC/Getting+Started>`_.
+`NuoDB wiki <http://doc.nuodb.com/display/doc/NuoDB+at+a+Glance>`_.
 
 License
 -------

--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ or using variables::
     print cursor.fetchone()
 
 For further information on getting started with NuoDB, please refer to the
-`NuoDB wiki <http://doc.nuodb.com/display/doc/NuoDB+at+a+Glance>`_.
+`NuoDB Documentation <http://doc.nuodb.com/display/doc/NuoDB+at+a+Glance>`_.
 
 License
 -------


### PR DESCRIPTION
The old link on the README no longer pointed to a hosted page, updated to our current getting started guide.