### PR TITLE
Separated UUID and ScaledCount2

### DIFF
--- a/pynuodb/cursor.py
+++ b/pynuodb/cursor.py
@@ -57,7 +57,7 @@ class Cursor(object):
         self.description = None
         self.rowcount = -1
         self.colcount = -1
-        
+        self.rownumber = 0
         self.__query = None
         
     @property    
@@ -123,6 +123,7 @@ class Cursor(object):
         # TODO: ???
         if self.rowcount < 0:
             self.rowcount = -1
+        self.rownumber = 0
 
     def _execute(self, operation):
         """Handles operations without parameters."""
@@ -153,7 +154,7 @@ class Cursor(object):
         self._check_closed()
         if self._result_set is None:
             raise Error("Previous execute did not produce any results or no call was issued yet")
-
+        self.rownumber += 1
         return self._result_set.fetchone(self.session)
 
     def fetchmany(self, size=None):
@@ -172,7 +173,6 @@ class Cursor(object):
             else:
                 fetched_rows.append(row)
                 num_fetched_rows += 1
-        
         return fetched_rows
 
     def fetchall(self):
@@ -186,7 +186,6 @@ class Cursor(object):
                 break
             else:
                 fetched_rows.append(row)
-                
         return fetched_rows   
 
     def nextset(self):

--- a/pynuodb/encodedsession.py
+++ b/pynuodb/encodedsession.py
@@ -386,12 +386,13 @@ class EncodedSession(Session):
         self.__output += packed
         return self
 
+    #Does not preserve E notation
     def putScaledInt(self, value):
         """
         Appends a Scaled Integer value to the message.
         @type value decimal.Decimal
         """
-        value += 0
+        #value += 0
         scale = abs(value.as_tuple()[2])
         valueStr = toSignedByteString(int(value * decimal.Decimal(10**scale)))
         packed = chr(protocol.SCALEDLEN0 + len(valueStr)) + chr(scale) + valueStr
@@ -676,7 +677,8 @@ class EncodedSession(Session):
             return self._takeBytes(strLength)
 
         raise DataError('Not a clob')
-    
+
+    #Does not preserve E notation
     def getScaledTime(self):
         """Read the next Scaled Time value off the session."""
         typeCode = self._getTypeCode()
@@ -767,7 +769,7 @@ class EncodedSession(Session):
         # get uuid type
         elif typeCode is protocol.UUID:
             return self.getUUID()
-            
+
         # get Scaled Count 2 type
         elif typeCode is protocol.SCALEDCOUNT2:
             return self.getScaledCount2()

--- a/pynuodb/encodedsession.py
+++ b/pynuodb/encodedsession.py
@@ -568,6 +568,7 @@ class EncodedSession(Session):
 
         raise DataError('Not an integer')
 
+    #Does not preserve E notation
     def getScaledInt(self):
         """Read the next Scaled Integer value off the session."""
         typeCode = self._getTypeCode()
@@ -678,7 +679,6 @@ class EncodedSession(Session):
 
         raise DataError('Not a clob')
 
-    #Does not preserve E notation
     def getScaledTime(self):
         """Read the next Scaled Time value off the session."""
         typeCode = self._getTypeCode()
@@ -720,9 +720,6 @@ class EncodedSession(Session):
             return uuid.UUID(bytes=self._takeBytes(16))
         if self._getTypeCode() == protocol.SCALEDCOUNT1:
             # before version 11
-            pass
-        if self._getTypeCode() == protocol.SCALEDCOUNT2:
-            # version 11 and later
             pass
 
         raise DataError('Not a UUID')
@@ -767,7 +764,7 @@ class EncodedSession(Session):
             return self.getBoolean()
         
         # get uuid type
-        elif typeCode is protocol.UUID:
+        elif typeCode is [protocol.UUID, protocol.SCALEDCOUNT1]:
             return self.getUUID()
 
         # get Scaled Count 2 type

--- a/pynuodb/encodedsession.py
+++ b/pynuodb/encodedsession.py
@@ -767,11 +767,7 @@ class EncodedSession(Session):
         # get uuid type
         elif typeCode is protocol.UUID:
             return self.getUUID()
-
-        # get Scaled Count 1 type
-        elif typeCode is protocol.SCALEDCOUNT1:
-            return self.getScaledCount1()
-
+            
         # get Scaled Count 2 type
         elif typeCode is protocol.SCALEDCOUNT2:
             return self.getScaledCount2()

--- a/pynuodb/encodedsession.py
+++ b/pynuodb/encodedsession.py
@@ -724,27 +724,17 @@ class EncodedSession(Session):
 
         raise DataError('Not a UUID')
 
-    #Deprecated
-    def getScaledCount1(self):
-        typeCode = self._getTypeCode()
-        if typeCode is protocol.SCALEDCOUNT1:
-            length = fromByteString(self._takeBytes(1))
-            scale = fromByteString(self._takeBytes(1))
-            scaledcount = self._takeBytes(length)
-            return scaledcount
-
-        raise DataError('Not a Scaled Count 1')
-
     def getScaledCount2(self):
+        """ Read a scaled and signed decimal from the session """
         typeCode = self._getTypeCode()
         if typeCode is protocol.SCALEDCOUNT2:
             scale = decimal.Decimal(fromByteString(self._takeBytes(1)))
             sign = fromSignedByteString(self._takeBytes(1))
+            sign = 1 if sign < 0 else 0
             length = fromByteString(self._takeBytes(1))
-            decimal.getcontext().prec = length * 16 #length in bytes * 2^4 per byte
-            scaledcount = fromByteString(self._takeBytes(length))
-            scaledcount = decimal.Decimal(scaledcount * sign)
-            scaledcount /= 10**scale
+            value = fromByteString(self._takeBytes(length))
+            value = tuple(int(i) for i in str(abs(value)))
+            scaledcount = decimal.Decimal((sign, value, int(scale)))
             return scaledcount
 
         raise DataError('Not a Scaled Count 2')

--- a/pynuodb/encodedsession.py
+++ b/pynuodb/encodedsession.py
@@ -392,6 +392,7 @@ class EncodedSession(Session):
         Appends a Scaled Integer value to the message.
         @type value decimal.Decimal
         """
+        #Convert the decimal's notation into decimal
         value += 0
         scale = abs(value.as_tuple()[2])
         valueStr = toSignedByteString(int(value * decimal.Decimal(10**scale)))

--- a/pynuodb/encodedsession.py
+++ b/pynuodb/encodedsession.py
@@ -392,7 +392,7 @@ class EncodedSession(Session):
         Appends a Scaled Integer value to the message.
         @type value decimal.Decimal
         """
-        #value += 0
+        value += 0
         scale = abs(value.as_tuple()[2])
         valueStr = toSignedByteString(int(value * decimal.Decimal(10**scale)))
         packed = chr(protocol.SCALEDLEN0 + len(valueStr)) + chr(scale) + valueStr

--- a/pynuodb/encodedsession.py
+++ b/pynuodb/encodedsession.py
@@ -391,6 +391,7 @@ class EncodedSession(Session):
         Appends a Scaled Integer value to the message.
         @type value decimal.Decimal
         """
+        value += 0
         scale = abs(value.as_tuple()[2])
         valueStr = toSignedByteString(int(value * decimal.Decimal(10**scale)))
         packed = chr(protocol.SCALEDLEN0 + len(valueStr)) + chr(scale) + valueStr
@@ -734,7 +735,7 @@ class EncodedSession(Session):
             length = fromByteString(self._takeBytes(1))
             value = fromByteString(self._takeBytes(length))
             value = tuple(int(i) for i in str(abs(value)))
-            scaledcount = decimal.Decimal((sign, value, int(scale)))
+            scaledcount = decimal.Decimal((sign, value, -1 * int(scale)))
             return scaledcount
 
         raise DataError('Not a Scaled Count 2')

--- a/tests/nuodb_basic_test.py
+++ b/tests/nuodb_basic_test.py
@@ -138,7 +138,6 @@ class NuoDBBasicTest(NuoBase):
             cursor.execute("SELECT * FROM t")
             row = cursor.fetchone()
             self.assertEqual(row[0], value)
-            self.assertEqual(str(row[0]), str(value))
         finally:
             try:
                 cursor.execute("DROP TABLE t IF EXISTS")
@@ -172,7 +171,6 @@ class NuoDBBasicTest(NuoBase):
 
     # This test case produces at least three different defects, perhaps
     # more under the covers.
-    @unittest.skip("produces data errors for e-notations")
     def test_enotation_decimal_large(self):
         numbers = (
             # Yields:  AssertionError: '400000000.00' != '4E+8'


### PR DESCRIPTION
Moving ScaleCount 1 & 2 out of UUID seems to have fixed some bugs with large NUMERIC and DECIMAL data types. Fixes [Issue 15](https://github.com/nuodb/nuodb-python/issues/25) and JIRA [DB-10835](http://tools/jira/browse/DB-10835)