### PR TITLE
Fixed invalid UTF-8 sequence in tests -- all tests passing

### DIFF
--- a/pynuodb/encodedsession.py
+++ b/pynuodb/encodedsession.py
@@ -21,7 +21,7 @@ from .statement import Statement, PreparedStatement, ExecutionResult
 from .result_set import ResultSet
 
 systemVersion = sys.version[0]
-
+REMOVE_FORMAT = 0
 class EncodedSession(Session):
     """Class for representing an encoded session with the database.
     
@@ -394,10 +394,10 @@ class EncodedSession(Session):
         @type value decimal.Decimal
         """
         #Convert the decimal's notation into decimal
-        value += 0
+        value += REMOVE_FORMAT
         scale = abs(value.as_tuple()[2])
         valueStr = toSignedByteString(int(value * decimal.Decimal(10**scale)))
-        
+
         #If our length is more than 9 bytes we will need to send the data using ScaledCount2
         if len(valueStr) > 9:
             return self.putScaledCount2(value)
@@ -640,8 +640,9 @@ class EncodedSession(Session):
             if typeCode < protocol.DOUBLELEN8:
                 for i in range(0, protocol.DOUBLELEN8 - typeCode):
                     test = test + chr(0)
-                if systemVersion is '3':
-                    return struct.unpack('!d', bytes(test, 'latin-1'))
+            if systemVersion is '3':
+                #Python 3 returns an array, we want the 0th element and remove form
+                return struct.unpack('!d', bytes(test, 'latin-1'))[0] + REMOVE_FORMAT
             return struct.unpack('!d', test)[0]
             
         raise DataError('Not a double')

--- a/pynuodb/encodedsession.py
+++ b/pynuodb/encodedsession.py
@@ -399,7 +399,7 @@ class EncodedSession(Session):
         valueStr = toSignedByteString(int(value * decimal.Decimal(10**scale)))
 
         #If our length is more than 9 bytes we will need to send the data using ScaledCount2
-        if len(valueStr) > 9:
+        if len(valueStr) > 8:
             return self.putScaledCount2(value)
 
         packed = chr(protocol.SCALEDLEN0 + len(valueStr)) + chr(scale) + valueStr

--- a/tests/nuodb_basic_test.py
+++ b/tests/nuodb_basic_test.py
@@ -153,7 +153,6 @@ class NuoDBBasicTest(NuoBase):
     #
     #   py.test -k "test_many_significant_digits"
     #
-    @unittest.skip("produces invalid UTF-8 code sequence")
     def test_many_significant_digits(self):
         self._test_decimal_fixture(decimal.Decimal("31943874831932418390.01"), 38, 12)
 


### PR DESCRIPTION
Decimal sequences longer than 9 bytes are now handled by putScaledCount2, before they were sent under the decimal protocol which would cause an invalid utf-8 sequence upon receiving. A few minor Python 3 fixes to putting data were made as well 