### PR TITLE
Fixed large dataset tests on Python 3

### DIFF
--- a/pynuodb/protocol.py
+++ b/pynuodb/protocol.py
@@ -329,8 +329,7 @@ def lookup_code(error_code):
 # NuoDB Client-Server Protocol Version #'s
 #
 PROTOCOL_VERSION1          = 1
-PROTOCOL_VERSION2          = 2   # 3/27/2011    Passing SQLState on exceptions; piggybacking generated
-                                 #              key result sets.
+PROTOCOL_VERSION2          = 2   # 3/27/2011    Passing SQLState on exceptions; piggybacking generated key result sets.
 PROTOCOL_VERSION3          = 3   # 2/14/2012    Passing txn, node id and commit sequence
 PROTOCOL_VERSION4          = 4   # 2/29/2012    Added GetCurrentSchema
 PROTOCOL_VERSION5          = 5   # 3/12/2012    Server returns DB UUID

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -4,4 +4,4 @@ pytest>=2.7
 coverage>=3.7
 pytest-cov>=1.8.1
 coveralls>=0.5
-python-coveralls>=2.5.0
+python-coveralls>=2.5


### PR DESCRIPTION
By preserving the type off the wire the driver no longer splices large results sets.

Fixed a code style issue in protocol.py

Updated required python-coveralls version