### PR TITLE
Added UTF-8 Support over the wire for python 3+

### DIFF
--- a/pynuodb/encodedsession.py
+++ b/pynuodb/encodedsession.py
@@ -411,6 +411,8 @@ class EncodedSession(Session):
         Appends a String to the message.
         @type value str
         """
+        if systemVersion is '3' and not self.isASCII(value):
+            value = value.encode('utf-8').decode('latin-1')
         length = len(value)
         if length < 40:
             packed = chr(protocol.UTF8LEN0 + length) + value
@@ -604,11 +606,17 @@ class EncodedSession(Session):
         typeCode = self._getTypeCode()
 
         if typeCode in range(protocol.UTF8LEN0, protocol.UTF8LEN39 + 1):
-            return self._takeBytes(typeCode - 109)
+            value = self._takeBytes(typeCode - 109)
+            if systemVersion is '3' and not self.isASCII(value):
+                value = value.encode('latin-1').decode('utf-8')
+            return value
 
         if typeCode in range(protocol.UTF8COUNT1, protocol.UTF8COUNT4 + 1):
             strLength = fromByteString(self._takeBytes(typeCode - 68))
-            return self._takeBytes(strLength)
+            value = self._takeBytes(strLength)
+            if systemVersion is '3' and not self.isASCII(value):
+                value = value.encode('latin-1').decode('utf-8')
+            return value
 
         raise DataError('Not a string')
 
@@ -873,3 +881,11 @@ class EncodedSession(Session):
             return self.__input[self.__inpos:self.__inpos + length]
         finally:
             self.__inpos += length
+
+    def isASCII(self, data):
+        try:
+            data.encode('ascii')
+        except UnicodeEncodeError:
+            return False
+        else:
+            return True

--- a/pynuodb/encodedsession.py
+++ b/pynuodb/encodedsession.py
@@ -445,7 +445,7 @@ class EncodedSession(Session):
         """Appends an Opaque data value to the message."""
         data = value.string
         length = len(data)
-        if systemVersion is '3' and type(value) is bytes:
+        if systemVersion is '3' and type(data) is bytes:
             data = data.decode('latin-1')
         if length < 40:
             packed = chr(protocol.OPAQUELEN0 + length) + data

--- a/pynuodb/session.py
+++ b/pynuodb/session.py
@@ -66,7 +66,7 @@ class SessionException(Exception):
 class Session(object):
 
     __AUTH_REQ = "<Authorize TargetService=\"%s\" Type=\"SRP\"/>"
-    __SRP_REQ = "<SRPRequest ClientKey=\"%s\" Cipher=\"RC4\" Username=\"%s\"/>" #Why is this hard coded...
+    __SRP_REQ = "<SRPRequest ClientKey=\"%s\" Cipher=\"%s\" Username=\"%s\"/>"
 
     __SERVICE_REQ = "<Request Service=\"%s\"%s/>"
     __SERVICE_CONN = "<Connect Service=\"%s\"%s/>"
@@ -104,15 +104,14 @@ class Session(object):
 
     # NOTE: This routine works only for agents ... see the sql module for a
     # still-in-progress example of opening an authorized engine session
-    def authorize(self, account="domain", password=None):
+    def authorize(self, account="domain", password=None, cipher='RC4'):
         if not password:
             raise SessionException("A password is required for authorization")
 
         cp = ClientPassword()
         key = cp.genClientKey()
-
         self.send(Session.__AUTH_REQ % self.__service)
-        response = self.__sendAndReceive(Session.__SRP_REQ % (key, account))
+        response = self.__sendAndReceive(Session.__SRP_REQ % (key, cipher, account))
 
         root = ElementTree.fromstring(response)
         if root.tag != "SRPResponse":


### PR DESCRIPTION
For the crypt.py transformation the information must be encoded as latin-1 (else the numeric values will be off when they are encrypted). If the string returns as non ascii we will encode it from utf-8 and decode it to latin-1 to preserve the values before encryption 

putString:(utf-8 to latin-1) -> RC4 Transform:(latin-1) -> send - (bytes) - receive -> RC4 Transform:(latin-1) -> getString:(latin-1 to utf-8).

Also made some preemptive changes for no cipher by changing the authorize function to except
 an option cipher type that defaults to RC4