### PR TITLE
Full python 3 support

### DIFF
--- a/pynuodb/encodedsession.py
+++ b/pynuodb/encodedsession.py
@@ -672,14 +672,18 @@ class EncodedSession(Session):
     
     def getOpaque(self):
         """Read the next Opaque value off the session."""
+
         typeCode = self._getTypeCode()
 
         if typeCode in range(protocol.OPAQUELEN0, protocol.OPAQUELEN39 + 1):
-            return datatype.Binary(self._takeBytes(typeCode - 149))
-
+            value = self._takeBytes(typeCode - 149)
+            return datatype.Binary(value)
         if typeCode in range(protocol.OPAQUECOUNT1, protocol.OPAQUECOUNT4 + 1):
             strLength = fromByteString(self._takeBytes(typeCode - 72))
-            return datatype.Binary(self._takeBytes(strLength))
+            value = self._takeBytes(strLength)
+            if systemVersion is '3':
+                value = value.encode('latin-1')
+            return datatype.Binary(value)
 
         raise DataError('Not an opaque value')
 

--- a/tests/nuodb_blob_test.py
+++ b/tests/nuodb_blob_test.py
@@ -16,16 +16,6 @@ class NuoDBBlobTest(NuoBase):
 
         binary_data = pack('hhl', 1, 2, 3)
 
-        cursor.execute("SELECT ? FROM DUAL", [binary_data])
-        row = cursor.fetchone()
-        
-        currentRow = row[0]
-        if systemVersion is '3':
-            currentRow = bytes(currentRow, 'latin-1')
-        array1 = unpack('hhl', currentRow)
-        self.assertEquals(len(array1), 3)
-        self.assertEquals(array1[2], 3)
-
         cursor.execute("SELECT ? FROM DUAL", [pynuodb.Binary(binary_data)])
         row = cursor.fetchone()
 


### PR DESCRIPTION
Added encode statement to encode latin decrypted string to bytes for large opaque objects 

Removed faulty test which sent binary as a string instead of using the binary object