### PR TITLE
Updated driver to set clientHost and clientProcessId

### DIFF
--- a/pynuodb/connection.py
+++ b/pynuodb/connection.py
@@ -13,7 +13,9 @@ from .cursor import Cursor
 from .encodedsession import EncodedSession
 from .crypt import ClientPassword, RC4Cipher
 from .util import getCloudEntry
+from os import getpid
 
+import platform
 import time
 
 apilevel = "2.0"
@@ -95,6 +97,9 @@ class Connection(object):
             parameters.update(options)
             if 'cipher' in options and options['cipher'] == 'None':
                 self.__session.set_encryption(False)
+
+        parameters['clientProcessId'] = str(getpid())
+        parameters['clientHost'] = platform.node()
 
         version, serverKey, salt = self.__session.open_database(dbName, parameters, cp)
             

--- a/pynuodb/encodedsession.py
+++ b/pynuodb/encodedsession.py
@@ -157,7 +157,6 @@ class EncodedSession(Session):
         self._putMessageId(protocol.OPENDATABASE).putInt(protocol.CURRENT_PROTOCOL_VERSION).putString(db_name).putInt(len(parameters))
         for (k, v) in parameters.items():
             self.putString(k).putString(v)
-
         self.putNull().putString(cp.genClientKey())
 
         self._exchangeMessages()

--- a/tests/nuodb_basic_test.py
+++ b/tests/nuodb_basic_test.py
@@ -459,6 +459,16 @@ class NuoDBBasicTest(NuoBase):
                 con.close()
 
     def test_connection_properties(self):
+        #Get NuoDB release 
+        con = self._connect()
+        cursor = con.cursor()
+        cursor.execute("select getReleaseversion() from dual")
+        version = cursor.fetchone()[0]
+        majorVersion = version[0]
+        minorVersion = version[2]
+        if(majorVersion is '2'):
+            if(minorVersion is not '3'):
+                return
 
         clientInfo = "NuoDB Python driver"
         tmp_args = self.connect_kw_args.copy()

--- a/tests/nuodb_basic_test.py
+++ b/tests/nuodb_basic_test.py
@@ -18,7 +18,7 @@ import pynuodb
 from .nuodb_base import NuoBase
 from .mock_tzs import EscapingTimestamp
 from .mock_tzs import Local
-from pynuodb.exception import DataError
+from pynuodb.exception import DataError, ProgrammingError
 
 
 class NuoDBBasicTest(NuoBase):
@@ -462,7 +462,11 @@ class NuoDBBasicTest(NuoBase):
         #Get NuoDB release 
         con = self._connect()
         cursor = con.cursor()
-        cursor.execute("select getReleaseversion() from dual")
+        try:
+            cursor.execute("select getReleaseversion() from dual")
+        except ProgrammingError as pe:
+            return #2.0 or earlier, skip test
+            
         version = cursor.fetchone()[0]
         majorVersion = version[0]
         minorVersion = version[2]

--- a/tests/nuodb_basic_test.py
+++ b/tests/nuodb_basic_test.py
@@ -469,9 +469,9 @@ class NuoDBBasicTest(NuoBase):
         result = cursor.fetchone()
 
         #Make sure our clientHost, clientProcessId and clientInfo remain the same in the SYSTEM.CONNECTIONS table
-        self.assertEqual(platform.node(), result[17])
-        self.assertEqual(str(os.getpid()), result[18])
-        self.assertEqual(clientInfo, result[19])
+        self.assertEqual(platform.node(), result[17]) #ClientHost
+        self.assertEqual(str(os.getpid()), result[18]) #clientProcessId
+        self.assertEqual(clientInfo, result[19]) #clientInfo
 
 
     def test_utf8_string_types(self):

--- a/tests/nuodb_basic_test.py
+++ b/tests/nuodb_basic_test.py
@@ -9,6 +9,7 @@ To create it run /opt/nuodb/run-quickstart or use the web console.
 
 import unittest
 import decimal
+import platform
 import time
 import os
 import sys
@@ -456,6 +457,22 @@ class NuoDBBasicTest(NuoBase):
                 cursor.execute("drop table typetest if exists")
             finally:
                 con.close()
+
+    def test_connection_properties(self):
+
+        clientInfo = "NuoDB Python driver"
+        tmp_args = self.connect_kw_args.copy()
+        tmp_args['options'] = {'schema': 'test', 'clientInfo': clientInfo}
+        con = pynuodb.connect(**tmp_args)#self._connect({'clientInfo':'Hello World'})
+        cursor = con.cursor()
+        cursor.execute("select * from SYSTEM.CONNECTIONS")
+        result = cursor.fetchone()
+
+        #Make sure our clientHost, clientProcessId and clientInfo remain the same in the SYSTEM.CONNECTIONS table
+        self.assertEqual(platform.node(), result[17])
+        self.assertEqual(str(os.getpid()), result[18])
+        self.assertEqual(clientInfo, result[19])
+
 
     def test_utf8_string_types(self):
         con = self._connect()


### PR DESCRIPTION
The driver now sets clientHost and clientProcessId on database connection. This is to prevent hangups or spoofing. 