### PR TITLE
[DB-12019] cursor.close() - fails to clear the result set with error thrown with NuoDB version >=2.1

### DIFF
--- a/pynuodb/cursor.py
+++ b/pynuodb/cursor.py
@@ -69,6 +69,8 @@ class Cursor(object):
         """Closes the cursor into the database."""
         self._check_closed()
         self._statement_cache.shutdown()
+        if self._result_set:
+            self._result_set.close(self.session)
         self.closed = True
 
     def _check_closed(self):
@@ -79,10 +81,7 @@ class Cursor(object):
             raise Error("connection is closed")
 
     def _reset(self):
-        """Resets SQL transaction variables.
-        
-        Also closes any open statements and result sets.
-        """
+        """Resets SQL transaction variables."""
         self.description = None
         self.rowcount = -1
         self.colcount = -1

--- a/pynuodb/encodedsession.py
+++ b/pynuodb/encodedsession.py
@@ -271,6 +271,13 @@ class EncodedSession(Session):
         self._putMessageId(protocol.CLOSESTATEMENT).putInt(statement.handle)
         self._exchangeMessages(False)
 
+    def close_result_set(self, result_set):
+        """
+        :type result_set: ResultSet
+        """
+        self._putMessageId(protocol.CLOSERESULTSET).putInt(result_set.handle)
+        self._exchangeMessages(False)
+
     def create_prepared_statement(self, query):
         """
         :type query: str

--- a/pynuodb/result_set.py
+++ b/pynuodb/result_set.py
@@ -35,3 +35,9 @@ class ResultSet(object):
         res = self.results[self.results_idx]
         self.results_idx += 1
         return res
+
+    def close(self, session):
+        """
+        :type session EncodedSession
+        """
+        session.close_result_set(self)

--- a/tests/nuodb_cursor_test.py
+++ b/tests/nuodb_cursor_test.py
@@ -129,7 +129,7 @@ class NuoDBCursorTest(NuoBase):
 
     def test_result_set_gets_closed(self):
         current_version = getenv('NUODB_VERSION', None) # skipif <2.1
-        if current_version is not None and LooseVersion(current_version) < LooseVersion("2.1"):
+        if current_version is not None and not LooseVersion(current_version) < LooseVersion("2.1"):
         # Server will throw error after 1000 open result sets
             con = self._connect()
             for j in [False, True]:

--- a/tests/nuodb_cursor_test.py
+++ b/tests/nuodb_cursor_test.py
@@ -4,6 +4,8 @@ import unittest
 
 from .nuodb_base import NuoBase
 from pynuodb.exception import DataError, ProgrammingError, BatchError, OperationalError
+from distutils.version import LooseVersion
+from os import getenv
 
 
 class NuoDBCursorTest(NuoBase):
@@ -126,26 +128,27 @@ class NuoDBCursorTest(NuoBase):
         cursor.execute("DROP TABLE executemany_table")
 
     def test_result_set_gets_closed(self):
+        current_version = getenv('NUODB_VERSION', None) # skipif <2.1
+        if current_version is not None and LooseVersion(current_version) < LooseVersion("2.1"):
         # Server will throw error after 1000 open result sets
-        con = self._connect()
-
-        for j in [False, True]:
-            for i in range(2015):
-                if not j:
-                    cursor = con.cursor()
-                    cursor.execute('select 1 from dual;')
-                    con.commit()
-                    cursor.close()
-                else:
-                    if i >= 1000:
-                        with self.assertRaises(OperationalError):
-                            cursor = con.cursor()
-                            cursor.execute('select 1 from dual;')
-                            con.commit()
-                    else:
+            con = self._connect()
+            for j in [False, True]:
+                for i in range(2015):
+                    if not j:
                         cursor = con.cursor()
                         cursor.execute('select 1 from dual;')
                         con.commit()
+                        cursor.close()
+                    else:
+                        if i >= 1000:
+                            with self.assertRaises(OperationalError):
+                                cursor = con.cursor()
+                                cursor.execute('select 1 from dual;')
+                                con.commit()
+                        else:
+                            cursor = con.cursor()
+                            cursor.execute('select 1 from dual;')
+                            con.commit()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The driver does not close the ResultSet and with newer versions of nuodb (>=2.1) an OperationalError is thrown similar to: 
```bash
...
    raise OperationalError(error_code_string + ': ' + error_string)
pynuodb.exception.OperationalError: 'INVALID_OPERATION: Maximum number of open statements (1000) exceeded'
```

Below is a code snippet that was used to generate the error.
```python
import pynuodb

connection = pynuodb.connect("local", "localhost", "dba", "dba", options={'schema':'platform'})
for i in range(10000):
    cursor = connection.cursor()
    cursor.execute('select 1 from dual;')
    connection.commit()
    cursor.close()
```

I believe there was a regression introduced between 2.0.4 and 2.1 that changed the behavior with how we handled ResultSets. 
* Added method close_result_set to encodedsession - used to pass messageId 28 over to the server
* Added method close to result_set - result_set objects should call close to officially kill the open resultSet with the server
* Any open result_set objects that are associated with a cursor will be closed when cursor.close() is called. Note that this still allows users to run into OperationError above since it is required to call cursor.close() to clean up after yourself. We could also implicitly cleanup for the user every time a new cursor object is created. 