### PR TITLE
Driver shouldn't set ClientHost - TE does this now

### DIFF
--- a/pynuodb/connection.py
+++ b/pynuodb/connection.py
@@ -99,7 +99,6 @@ class Connection(object):
                 self.__session.set_encryption(False)
 
         parameters['clientProcessId'] = str(getpid())
-        parameters['clientHost'] = platform.node()
 
         version, serverKey, salt = self.__session.open_database(dbName, parameters, cp)
             

--- a/tests/nuodb_basic_test.py
+++ b/tests/nuodb_basic_test.py
@@ -155,7 +155,7 @@ class NuoDBBasicTest(NuoBase):
             DataError
             cursor.execute("INSERT INTO t (x) VALUES (?)", (value,))
             cursor.execute("SELECT * FROM t")
-            
+
         except DataError as err:
             if "CONVERSION_ERROR" not in str(err):
                 self.fail()
@@ -459,15 +459,15 @@ class NuoDBBasicTest(NuoBase):
                 con.close()
 
     def test_connection_properties(self):
-        #Get NuoDB release 
+        #Get NuoDB release
         con = self._connect()
         cursor = con.cursor()
         try:
             cursor.execute("select getReleaseversion() from dual")
         except ProgrammingError as pe:
             return #2.0 or earlier, skip test
-        
-        #Determine NuoDB version in the form Major.Minor    
+
+        #Determine NuoDB version in the form Major.Minor
         version = cursor.fetchone()[0]
         majorVersion = int(version[0])
         minorVersion = int(version[2])
@@ -480,13 +480,12 @@ class NuoDBBasicTest(NuoBase):
         tmp_args['options'] = {'schema': 'test', 'clientInfo': clientInfo}
         con = pynuodb.connect(**tmp_args)
         cursor = con.cursor()
-        cursor.execute("select * from SYSTEM.CONNECTIONS")
+        cursor.execute("select clientprocessid, clientinfo from SYSTEM.CONNECTIONS")
         result = cursor.fetchone()
 
-        #Make sure our clientHost, clientProcessId and clientInfo remain the same in the SYSTEM.CONNECTIONS table
-        self.assertEqual(platform.node(), result[17]) #ClientHost
-        self.assertEqual(str(os.getpid()), result[18]) #clientProcessId
-        self.assertEqual(clientInfo, result[19]) #clientInfo
+        #Make sure our clientProcessId and clientInfo remain the same in the SYSTEM.CONNECTIONS table
+        self.assertEqual(str(os.getpid()), result[0]) #clientProcessId
+        self.assertEqual(clientInfo, result[1]) #clientInfo
 
 
     def test_utf8_string_types(self):
@@ -525,9 +524,9 @@ class NuoDBBasicTest(NuoBase):
                            "time_col time, timestamp_col_EDT timestamp, timestamp_col_EST timestamp)")
 
             test_vals = (
-                pynuodb.Date(2008, 1, 1), 
-                pynuodb.Time(8, 13, 34), 
-                pynuodb.Timestamp(2014, 12, 19, 14, 8, 30, 99, Local), 
+                pynuodb.Date(2008, 1, 1),
+                pynuodb.Time(8, 13, 34),
+                pynuodb.Timestamp(2014, 12, 19, 14, 8, 30, 99, Local),
                 pynuodb.Timestamp(2014, 7, 23, 6, 22, 19, 88, Local),
                 )
             quoted_vals = ["'%s'" % str(val) for val in test_vals]


### PR DESCRIPTION
Since the TE will now handle setting the ClientHost value, we no longer need to set it within the Driver. 

* No longer setting the ClientHost when we create a Connection.
* Explicitly using clientprocessid, clientinfo within the select statement.
* Removed the check for ClientHost test_connection_properties. Since we don't handle the setting of ClientHost value, it seems out of scope for the test to validate a proper ClientHost value was set. For example if the TE was running on some random remote machine there is no way for the driver to actually know beforehand the hostname of that remote machine. 