### PR TITLE
[DB-12501] Will implicitly close resultset on execute

### DIFF
--- a/pynuodb/cursor.py
+++ b/pynuodb/cursor.py
@@ -69,8 +69,7 @@ class Cursor(object):
         """Closes the cursor into the database."""
         self._check_closed()
         self._statement_cache.shutdown()
-        if self._result_set:
-            self._result_set.close(self.session)
+        self._close_result_set()
         self.closed = True
 
     def _check_closed(self):
@@ -80,12 +79,19 @@ class Cursor(object):
         if self.session.closed:
             raise Error("connection is closed")
 
+    def _close_result_set(self):
+        """Close current ResultSet on client and server side"""
+        if self._result_set:
+            self._result_set.close(self.session)
+            self._result_set = None
+
     def _reset(self):
-        """Resets SQL transaction variables."""
+        """Resets Cursor to a default SQL transaction state"""
         self.description = None
         self.rowcount = -1
         self.colcount = -1
-        self._result_set = None
+        self._close_result_set()
+
 
     def callproc(self, procname, parameters=None):
         """Currently not supported."""

--- a/tests/nuodb_executionflow_test.py
+++ b/tests/nuodb_executionflow_test.py
@@ -191,6 +191,18 @@ class NuoDBExecutionFlowTest(NuoBase):
                 self.assertEqual(str(e1),
                                  "'SYNTAX_ERROR: syntax error on line 1\\nsyntax2 error\\n^ expected statement got syntax2\\n'")
 
+    def test_execute_ten_million_with_result_sets(self):
+        con = self._connect()
+        cursor = con.cursor()
+        cursor.execute("DROP TABLE IF EXISTS execute_ten_million_with_result_sets")
+        cursor.execute("CREATE TABLE execute_ten_million_with_result_sets (value INTEGER)")
+        for i in range(10000):
+            cursor.execute("insert into execute_ten_million_with_result_sets (value) Values ({:d})".format(i))
+            con.commit()
+            cursor.execute("select count(*) from execute_ten_million_with_result_sets;")
+            res = cursor.fetchone()[0]
+            self.assertEqual(i+1,res)
+
 
 def version_lt(version):
     current_version = os.getenv('NUODB_VERSION', None)


### PR DESCRIPTION
Any open resultset for a single cursor object will now be closed implicitly when execute is called. 