### PR TITLE
Support latest NuoDB releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,8 @@ env:
   global:
     - TZ=America/New_York
     - NUO_DOWNLOAD=https://ce-downloads.nuohub.org
-    - NUO_PREFIX=nuodb-ce
+    - NUO_ARCH=linux.x86_64
     - NUO_SET_TLS=disable
-    - NUODB_HOME=/opt/nuodb
 
 notifications:
   recipients:
@@ -22,20 +21,21 @@ before_install:
   - echo madvise | sudo tee /sys/kernel/mm/transparent_hugepage/enabled >/dev/null
   - echo madvise | sudo tee /sys/kernel/mm/transparent_hugepage/defrag >/dev/null
   - wget -q "$NUO_DOWNLOAD/supportedversions.txt" --output-document=/tmp/supportedversions.txt
-  - wget -q "$NUO_DOWNLOAD/${NUO_PREFIX}_$(tail -n1 /tmp/supportedversions.txt)_amd64.deb" --output-document=/var/tmp/nuodb.deb
-  - sudo dpkg -i /var/tmp/nuodb.deb
-  - echo "NuoDB Version:" && $NUODB_HOME/bin/nuodb --version
+  - wget -q "$NUO_DOWNLOAD/nuodb-$(tail -n1 /tmp/supportedversions.txt).$NUO_ARCH.tar.gz" --output-document=/var/tmp/nuodb.tgz
+  - mkdir -p "$HOME/nuodb"
+  - cd "$HOME/nuodb" && tar xzf /var/tmp/nuodb.tgz --strip-components 1
+  - echo "NuoDB Version:" && "$HOME/nuodb/bin/nuodb" --version
 
 install:
   - make install
 
 before_script:
-  - sudo -n $NUODB_HOME/etc/nuoadmin tls $NUO_SET_TLS
-  - sudo -n systemctl start nuoadmin
+  - "$HOME/nuodb/etc/nuoadmin" tls $NUO_SET_TLS
+  - "$HOME/nuodb/etc/nuoadmin" start
 
 script:
-  - make test NUODB_HOME=$NUODB_HOME
+  - make test NUODB_HOME="$HOME/nuodb"
 
 after_failure:
-  - cat /var/log/nuodb/nuoadmin.log*
-  - grep ssl /etc/nuodb/nuoadmin.conf
+  - cat "$HOME"/nuodb/var/log/nuoadmin.log*
+  - grep ssl "$HOME/nuodb/etc/nuoadmin.conf"


### PR DESCRIPTION
- DEB packages are no longer produced: switch to TAR
- The download is renamed from nuodb-ce to nuodb.