### PR TITLE
TypeObjectFromNuodb needs to be able to handle type 'timestamp withou…

### DIFF
--- a/pynuodb/datatype.py
+++ b/pynuodb/datatype.py
@@ -178,7 +178,8 @@ TYPEMAP = {"<null>": None,
            "binarystring": BINARY,
            "binaryvaryingstring": BINARY,
            "boolean": NUMBER,
-           "binary": BINARY}
+           "binary": BINARY,
+           "timestamp without time zone" : DATETIME }
 
 
 def TypeObjectFromNuodb(nuodb_type_name):


### PR DESCRIPTION
…t time zone'

Query:   select convert_tz('2014-01-01','GMT',"EST') from dual;

fails because python driver does not understand 'timestamp without time zone'.   