### PR TITLE
Add support for missing SQL data types

### DIFF
--- a/pynuodb/datatype.py
+++ b/pynuodb/datatype.py
@@ -1,6 +1,6 @@
 """A module for housing the datatype classes.
 
-(C) Copyright 2013-2023 Dassault Systemes SE.  All Rights Reserved.
+(C) Copyright 2013-2025 Dassault Systemes SE.  All Rights Reserved.
 
 This software is licensed under a BSD 3-Clause License.
 See the LICENSE file provided with this software.
@@ -158,27 +158,29 @@ TYPEMAP = {"<null>": None,
            "string": STRING,
            "char": STRING,
            "varchar": STRING,
-           "text": STRING,
            "smallint": NUMBER,
            "integer": NUMBER,
            "bigint": NUMBER,
            "float": NUMBER,
            "double": NUMBER,
-           "decimal": NUMBER,
-           "double precision": NUMBER,
            "date": DATETIME,
            "timestamp": DATETIME,
-           "datetime": DATETIME,
            "time": DATETIME,
            "clob": BINARY,
            "blob": BINARY,
            "numeric": NUMBER,
            "number": NUMBER,
            "bytes": BINARY,
+           "binary": BINARY,
+           "binary varying": BINARY,
+           "boolean": NUMBER,
+           "timestamp without time zone": DATETIME,
+           "timestamp with time zone": DATETIME,
+           "time without time zone": DATETIME,
+           # Old types used by NuoDB <2.0.3
            "binarystring": BINARY,
            "binaryvaryingstring": BINARY,
-           "boolean": NUMBER,
-           "binary": BINARY}
+           }
 
 
 def TypeObjectFromNuodb(nuodb_type_name):

--- a/tests/nuodb_types_test.py
+++ b/tests/nuodb_types_test.py
@@ -1,0 +1,114 @@
+"""
+(C) Copyright 2025 Dassault Systemes SE.  All Rights Reserved.
+
+This software is licensed under a BSD 3-Clause License.
+See the LICENSE file provided with this software.
+"""
+
+import decimal
+import datetime
+
+from . import nuodb_base
+
+
+class TestNuoDBTypes(nuodb_base.NuoBase):
+    def test_boolean_types(self):
+        con = self._connect()
+        cursor = con.cursor()
+
+        cursor.execute("CREATE TEMPORARY TABLE tmp (v1 BOOLEAN)")
+        cursor.execute("INSERT INTO tmp VALUES (true)")
+
+        cursor.execute("SELECT * FROM tmp")
+        row = cursor.fetchone()
+
+        assert len(row) == 1
+        assert row[0]
+
+    def test_string_types(self):
+        con = self._connect()
+        cursor = con.cursor()
+
+        cursor.execute("CREATE TEMPORARY TABLE tmp ("
+                       " v1 STRING,"
+                       " v2 CHARACTER,"
+                       " v3 CHARACTER LARGE OBJECT)")
+        cursor.execute("INSERT INTO tmp VALUES ('simple', 'a', 'clob')")
+
+        cursor.execute("SELECT * FROM tmp")
+        row = cursor.fetchone()
+
+        assert len(row) == 3
+        assert row[0] == 'simple'
+        assert row[1] == 'a'
+        assert row[2] == 'clob'
+
+    def test_numeric_types(self):
+        con = self._connect()
+        cursor = con.cursor()
+
+        cursor.execute("CREATE TEMPORARY TABLE tmp ("
+                       " v1 SMALLINT,"
+                       " v2 INTEGER,"
+                       " v3 BIGINT,"
+                       " v4 NUMERIC(30, 1),"
+                       " v5 FLOAT,"
+                       " v6 DOUBLE)")
+
+        cursor.execute("INSERT INTO tmp VALUES (1, 2, 9223372036854775807,"
+                       " 9223372036854775807111.5, 5.6, 7.8)")
+
+        cursor.execute("SELECT * FROM tmp")
+        row = cursor.fetchone()
+
+        assert len(row) == 6
+        assert row[0] == 1
+        assert row[1] == 2
+        assert row[2] == 9223372036854775807
+        assert row[3] == decimal.Decimal('9223372036854775807111.5')
+        assert row[4] == 5.6
+        assert row[5] == 7.8
+
+    def test_binary_types(self):
+        con = self._connect()
+        cursor = con.cursor()
+
+        cursor.execute("CREATE TEMPORARY TABLE tmp ("
+                       " v1 BLOB,"
+                       " v2 BINARY,"
+                       " v3 BINARY VARYING(10))")
+
+        cursor.execute("INSERT INTO tmp VALUES ('foo', 'a', 'barbaz')")
+
+        cursor.execute("SELECT * FROM tmp")
+        row = cursor.fetchone()
+
+        assert len(row) == 3
+        assert row[0] == b'foo'
+        assert row[1] == b'a'
+        assert row[2] == b'barbaz'
+
+    def test_datetime_types(self):
+        con = self._connect()
+        cursor = con.cursor()
+
+        cursor.execute("CREATE TEMPORARY TABLE tmp ("
+                       " v1 DATE,"
+                       " v2 TIME,"
+                       " v3 TIMESTAMP,"
+                       " v4 TIMESTAMP WITHOUT TIME ZONE)")
+
+        cursor.execute("INSERT INTO tmp VALUES ("
+                       " '1/1/2000',"
+                       " '05:44:33.2211',"
+                       " '1/1/2000 05:44:33.2211',"
+                       " '1/1/2000 05:44:33.2211')")
+
+        cursor.execute("SELECT * FROM tmp")
+        row = cursor.fetchone()
+
+        assert len(row) == 4
+        assert row[0] == datetime.date(2000, 1, 1)
+        assert row[1] == datetime.time(5, 44, 33, 221100)
+        assert row[2] == datetime.datetime(2000, 1, 1, 5, 44, 33, 221100)
+        assert row[3] == datetime.datetime(2000, 1, 1, 5, 44, 33, 221100)


### PR DESCRIPTION
The following types were added:
* binary varying
* timestamp without timezone

Added tests for the different types.

Addresses bug #160 