### PR TITLE
Start to increase the support client protocol for the python driver

### DIFF
--- a/pynuodb/protocol.py
+++ b/pynuodb/protocol.py
@@ -369,5 +369,5 @@ PREPARE_AND_EXECUTE_TOGETHER                    = 26
 # The newest feature this driver supports.
 # The server will negotiate the highest compatible version.
 CURRENT_PROTOCOL_MAJOR     = 1
-CURRENT_PROTOCOL_VERSION   = SEND_PREPARE_STMT_RESULT_SET_METADATA_TO_CLIENT
+CURRENT_PROTOCOL_VERSION   = DDL_NOT_AUTOCOMMITTED
 AUTH_TEST_STR              = 'Success!'

--- a/pynuodb/protocol.py
+++ b/pynuodb/protocol.py
@@ -369,5 +369,5 @@ PREPARE_AND_EXECUTE_TOGETHER                    = 26
 # The newest feature this driver supports.
 # The server will negotiate the highest compatible version.
 CURRENT_PROTOCOL_MAJOR     = 1
-CURRENT_PROTOCOL_VERSION   = BIGINT_ENCODE_VER3
+CURRENT_PROTOCOL_VERSION   = SEND_PREPARE_STMT_RESULT_SET_METADATA_TO_CLIENT
 AUTH_TEST_STR              = 'Success!'

--- a/pynuodb/protocol.py
+++ b/pynuodb/protocol.py
@@ -369,5 +369,5 @@ PREPARE_AND_EXECUTE_TOGETHER                    = 26
 # The newest feature this driver supports.
 # The server will negotiate the highest compatible version.
 CURRENT_PROTOCOL_MAJOR     = 1
-CURRENT_PROTOCOL_VERSION   = XA_TRANSACTIONS
+CURRENT_PROTOCOL_VERSION   = BIGINT_ENCODE_VER3
 AUTH_TEST_STR              = 'Success!'

--- a/pynuodb/statement.py
+++ b/pynuodb/statement.py
@@ -6,6 +6,11 @@ This software is licensed under a BSD 3-Clause License.
 See the LICENSE file provided with this software.
 """
 
+try:
+    from typing import Any, List, Optional  # pylint: disable=unused-import
+except ImportError:
+    pass
+
 
 class Statement(object):
     """A SQL statement."""
@@ -31,6 +36,7 @@ class PreparedStatement(Statement):
         """
         super(PreparedStatement, self).__init__(handle)
         self.parameter_count = parameter_count
+        self.description = None  # type: Optional[List[List[Any]]]
 
 
 class ExecutionResult(object):


### PR DESCRIPTION
These commits update the client to support these new capabilities:
* SCALEDCOUNT3 : Support newer BIGINT encoding
* Support receiving resultset metadata in the prepare statement results
* Support not autocommitting DDL (there is no change needed in the Python driver)