### PR TITLE
cursor.description should use column_label and not column_name.

### DIFF
--- a/pynuodb/encodedsession.py
+++ b/pynuodb/encodedsession.py
@@ -436,8 +436,8 @@ class EncodedSession(Session):  # pylint: disable=too-many-public-methods
             self.getString()    # catalog_name
             self.getString()    # schema_name
             self.getString()    # table_name
-            column_name = self.getString()
-            self.getString()    # column_label
+            self.getString()    # column_name
+            column_label = self.getString()    # column_label
             self.getValue()     # collation_sequence
             column_type_name = self.getString()
             self.getInt()       # column_type
@@ -448,7 +448,7 @@ class EncodedSession(Session):  # pylint: disable=too-many-public-methods
 
             # TODO: type information should be derived from the type
             # (column_type) not the typename.
-            description[i] = [column_name, TypeObjectFromNuodb(column_type_name),
+            description[i] = [column_label, TypeObjectFromNuodb(column_type_name),
                               column_display_size, None, precision, scale, None]
 
         return description


### PR DESCRIPTION
the column name should be the column_label and that is returned.  I don't know if this is a typo between label or name in the python driver compared to the client protocol or what.  But this implementation looks like it gives the correct result.

create table t(a integer);
select a as b from t;

with previous implementation the cursor.description would have ('a'....)
with this implementation the cursor.description would have ('b'...)

