### PR TITLE
A change to the field returned from the TE to use for column_name.

### DIFF
--- a/pynuodb/datatype.py
+++ b/pynuodb/datatype.py
@@ -154,8 +154,9 @@ BINARY = TypeObject(str)
 NUMBER = TypeObject(int, decimal.Decimal)
 DATETIME = TypeObject(Timestamp, Date, Time)
 ROWID = TypeObject()
+NULL = TypeObject(None)
 
-TYPEMAP = {"<null>": None,
+TYPEMAP = {"<null>": NULL,
            "string": STRING,
            "char": STRING,
            "varchar": STRING,

--- a/pynuodb/encodedsession.py
+++ b/pynuodb/encodedsession.py
@@ -469,8 +469,8 @@ class EncodedSession(session.Session):  # pylint: disable=too-many-public-method
             self.getString()    # catalog_name
             self.getString()    # schema_name
             self.getString()    # table_name
-            column_name = self.getString()
-            self.getString()    # column_label
+            self.getString()    # column_name
+            column_label = self.getString()    # column_label
             self.getValue()     # collation_sequence
             column_type_name = self.getString()
             self.getInt()       # column_type
@@ -481,7 +481,7 @@ class EncodedSession(session.Session):  # pylint: disable=too-many-public-method
 
             # TODO: type information should be derived from the type
             # (column_type) not the typename.
-            description[i] = [column_name,
+            description[i] = [column_label,
                               datatype.TypeObjectFromNuodb(column_type_name),
                               column_display_size, None, precision, scale, None]
 

--- a/tests/nuodb_description_name_test.py
+++ b/tests/nuodb_description_name_test.py
@@ -1,0 +1,27 @@
+"""
+(C) Copyright 2025 Dassault Systemes SE.  All Rights Reserved.
+
+This software is licensed under a BSD 3-Clause License.
+See the LICENSE file provided with this software.
+"""
+
+import decimal
+import datetime
+
+from . import nuodb_base
+
+
+class TestNuoDBDescription(nuodb_base.NuoBase):
+
+    def test_description(self):
+        con = self._connect()
+        cursor = con.cursor()
+
+        cursor.execute("CREATE TEMPORARY TABLE tmp (v1 INTEGER, v2 STRING)" )
+        cursor.execute("INSERT INTO tmp VALUES (1,'a'), (2,'b')")
+        cursor.execute("SELECT v1 AS c1, concat(v2,'') as c2 FROM tmp")
+        row = cursor.fetchone()
+        d = cursor.description
+
+        assert d[0][0].lower() == 'c1'
+        assert d[1][0].lower() == 'c2'


### PR DESCRIPTION
column_name does not seem to be what we want,  use column_label
instead.   Or the order of these two fields are incorrect from
the order that engine is sending the data.

Test case nuodb_description_name_test.py shows failure before this change.