### PR TITLE
handle <null> type in query results

### DIFF
--- a/pynuodb/datatype.py
+++ b/pynuodb/datatype.py
@@ -154,8 +154,9 @@ BINARY = TypeObject(str)
 NUMBER = TypeObject(int, decimal.Decimal)
 DATETIME = TypeObject(Timestamp, Date, Time)
 ROWID = TypeObject()
+NULL = TypeObject(None)
 
-TYPEMAP = {"<null>": None,
+TYPEMAP = {"<null>": NULL,
            "string": STRING,
            "char": STRING,
            "varchar": STRING,

--- a/tests/nuodb_types_test.py
+++ b/tests/nuodb_types_test.py
@@ -112,3 +112,16 @@ class TestNuoDBTypes(nuodb_base.NuoBase):
         assert row[1] == datetime.time(5, 44, 33, 221100)
         assert row[2] == datetime.datetime(2000, 1, 1, 5, 44, 33, 221100)
         assert row[3] == datetime.datetime(2000, 1, 1, 5, 44, 33, 221100)
+
+    def test_null_type(self):
+        con = self._connect()
+        cursor = con.cursor()
+
+        null_type = self.driver.TypeObjectFromNuodb('<null>')
+
+        cursor.execute("SELECT NULL from dual")
+        row = cursor.fetchone()
+
+        assert len(row) == 1
+        assert cursor.description[0][1] == null_type
+        assert row[0] is None


### PR DESCRIPTION
In order to support a <null> type column being returned from engine.  A TypeObject is needed instead of returning None.  As None is used to verify that the type returned is in the TYPEMAP.

cursor.execute('select NULL from DUAL')

fails without this change.  There are other cases where a user might explictly return NULL in place of an actual value.  Say in a view such as INFORMATION_SCHEMA.COLUMNS where we don't support DOMAIN_NAME column.

The above example was added to tests/nuodb_types_test.py