### PR TITLE
Add full support for protocol.LAST_COMMIT_INFO (#45)

### DIFF
--- a/pynuodb/connection.py
+++ b/pynuodb/connection.py
@@ -12,7 +12,8 @@ Exported Functions:
 connect -- Creates a connection object.
 """
 
-__all__ = ['apilevel', 'threadsafety', 'paramstyle', 'connect', 'Connection']
+__all__ = ['apilevel', 'threadsafety', 'paramstyle', 'connect',
+           'reset', 'Connection']
 
 import os
 import copy
@@ -57,6 +58,17 @@ def connect(database=None,  # type: Optional[str]
     return Connection(database=database, host=host,
                       user=user, password=password,
                       options=options, **kwargs)
+
+
+def reset():
+    # type: () -> None
+    """Reset the module to its initial state.
+
+    Forget any global state maintained by the module.
+    NOTE: this does not impact existing connections or cursors.
+    It only impacts new connections.
+    """
+    encodedsession.EncodedSession.reset()
 
 
 class Connection(object):

--- a/pynuodb/session.py
+++ b/pynuodb/session.py
@@ -470,14 +470,12 @@ class Session(object):
         # don't have to reallocate this entire buffer, but it is unreliable.
         buf = lenbuf + data
         view = memoryview(buf)
-        start = 0
-        left = len(buf)
+        end = len(buf)
+        cur = 0
 
         try:
-            while left > 0:
-                sent = sock.send(view[start:left])
-                start += sent
-                left -= sent
+            while cur < end:
+                cur += sock.send(view[cur:])
         except Exception:
             self.close()
             raise


### PR DESCRIPTION
Previously the LAST_COMMIT_INFO feature was only supported at the protocol level: the driver always reported there was no information available about the last commit.

Last commit ensures "read your own writes" capability for committed transactions, even when connections are using different TEs.

Implement an internal structure to store last commit information:
- The information is saved as a process-wide set of data
- Allows the same process to connect to different databases, and to connect to the same database multiple times (to the same or to different TEs).

In order to support Python clients that may use threading with different connections, use a Lock() to access the last commit details.  Python threading doesn't provide reader/writer locks; rather than write one we'll use a simple mutex and assume this won't be a performance bottleneck.