### PR TITLE
[DPY-14] Keep server time zone in sync with client time zone

### DIFF
--- a/pynuodb/encodedsession.py
+++ b/pynuodb/encodedsession.py
@@ -401,9 +401,9 @@ class EncodedSession(session.Session):  # pylint: disable=too-many-public-method
         """
         self._setup_statement(stmt.handle, protocol.EXECUTE).putString(query)
         self._exchangeMessages()
+
         result = self.getInt()
         rowcount = self.getInt()
-
         self.__execute_postfix()
 
         return statement.ExecutionResult(stmt, result, rowcount)
@@ -453,7 +453,6 @@ class EncodedSession(session.Session):  # pylint: disable=too-many-public-method
 
         result = self.getInt()
         rowcount = self.getInt()
-        
         self.__execute_postfix()
 
         return statement.ExecutionResult(prepared_statement, result, rowcount)
@@ -505,6 +504,7 @@ class EncodedSession(session.Session):  # pylint: disable=too-many-public-method
 
         handle = self.getInt()
         colcount = self.getInt()
+
         # skip the header labels
         for _ in range(colcount):
             self.getString()
@@ -1113,18 +1113,19 @@ class EncodedSession(session.Session):  # pylint: disable=too-many-public-method
     
     def getScaledTimestampNoTz(self):
         # type: () -> datatype.Timestamp
-        """Read the next Scaled Timestamp value off the session as a naive datetime.
+        """Read the next Scaled Timestamp without timezone value off the session.
 
         :rtype: datetime.datetime
         """
         code = self._getTypeCode()
+
         if code == protocol.SCALEDTIMESTAMPNOTZ:
             scale = crypt.fromByteString(self._takeBytes(1))
             stamp = crypt.fromSignedByteString(self._takeBytes(code-protocol.SCALEDTIMESTAMPNOTZLEN0))
             seconds, micros = self.__unpack(scale, stamp)
             return datatype.TimestampFromTicks(seconds, micros, None)
-        raise DataError('Not a scaled timestamp without time zone')
 
+        raise DataError('Not a scaled timestamp without time zone')
 
     def getScaledDate(self):
         # type: () -> datatype.Date

--- a/pynuodb/encodedsession.py
+++ b/pynuodb/encodedsession.py
@@ -382,10 +382,12 @@ class EncodedSession(session.Session):  # pylint: disable=too-many-public-method
 
     def __execute_postfix(self):
         # type: () -> None
-        tzUpdate = self.getBoolean()
-        if tzUpdate:
-            server_tz = self.getValue()
-            self.__timezone_name = server_tz
+        if self.__sessionVersion >= protocol.TIMESTAMP_WITHOUT_TZ:
+            tzUpdate = self.getBoolean()
+            if tzUpdate:
+                server_tz = self.getValue()
+                self.__timezone_name = server_tz
+        
         txid = self.getInt()
         sid = self.getInt()
         seqid = self.getInt()

--- a/pynuodb/protocol.py
+++ b/pynuodb/protocol.py
@@ -61,10 +61,12 @@ LOBSTREAM0                        = 226
 LOBSTREAM1                        = 227
 LOBSTREAM4                        = 230
 ARRAYLEN1                         = 231
+SCALEDTIMESTAMPNOTZLEN0           = 233
 ARRAYLEN8                         = 238
 SCALEDCOUNT3                      = 239
 DEBUGBARRIER                      = 240
 SCALEDTIMESTAMPNOTZ               = 241
+
 
 # subtypes of the VECTOR type
 VECTOR_DOUBLE                     = 0
@@ -377,5 +379,5 @@ PREPARE_AND_EXECUTE_TOGETHER                    = 26
 # The newest feature this driver supports.
 # The server will negotiate the highest compatible version.
 CURRENT_PROTOCOL_MAJOR     = 1
-CURRENT_PROTOCOL_VERSION   = CURSOR_HOLDABILITY
+CURRENT_PROTOCOL_VERSION   = TIMESTAMP_WITHOUT_TZ
 AUTH_TEST_STR              = 'Success!'

--- a/pynuodb/protocol.py
+++ b/pynuodb/protocol.py
@@ -67,7 +67,6 @@ SCALEDCOUNT3                      = 239
 DEBUGBARRIER                      = 240
 SCALEDTIMESTAMPNOTZ               = 241
 
-
 # subtypes of the VECTOR type
 VECTOR_DOUBLE                     = 0
 


### PR DESCRIPTION
 A new feature to the client protocol that allows the client to inform the server of its local time zone. This influences the value returned in results for timestamp-with-timezone columns.
 
 