### PR TITLE
[DPY-15] Support PREPARE_AND_EXECUTE_TOGETHER

### DIFF
--- a/pynuodb/cursor.py
+++ b/pynuodb/cursor.py
@@ -165,7 +165,7 @@ class Cursor(object):
         :raises ProgrammingError: Incorrect number of parameters
         """
         p_statement = self._statement_cache.get_prepared_statement(operation)
-        if p_statement.parameter_count != len(parameters):
+        if p_statement.parameter_count != len(parameters) and p_statement.handle != -1:
             raise ProgrammingError(
                 "Incorrect number of parameters: expected %d, got %d" %
                 (p_statement.parameter_count, len(parameters)))
@@ -275,8 +275,7 @@ class StatementCache(object):
             self._ps_key_queue.append(query)
             return stmt
 
-        stmt = self._session.create_prepared_statement(query)
-
+        stmt = self._session.create_local_prepared_statement(query)
         while len(self._ps_cache) >= self._ps_cache_size:
             lru_statement_key = self._ps_key_queue.popleft()
             statement_to_remove = self._ps_cache[lru_statement_key]

--- a/pynuodb/encodedsession.py
+++ b/pynuodb/encodedsession.py
@@ -359,9 +359,10 @@ class EncodedSession(session.Session):  # pylint: disable=too-many-public-method
         self._putMessageId(protocol.CREATE)
         self._exchangeMessages()
         handle = self.getInt()
+        stmt = statement.Statement(handle)
 
-        # Use handle to query dual
-        self._setup_statement(handle, protocol.EXECUTEQUERY)
+        # Use statement to query dual
+        self._setup_statement(stmt, protocol.EXECUTEQUERY)
         self.putString('select 1 as one from dual')
         self._exchangeMessages()
 
@@ -401,7 +402,8 @@ class EncodedSession(session.Session):  # pylint: disable=too-many-public-method
         :param query: Operation to be executed.
         :returns: The result of the operation execution.
         """
-        self._setup_statement(stmt.handle, protocol.EXECUTE).putString(query)
+        stmt.query = query
+        self._setup_statement(stmt, protocol.EXECUTE).putString(query)
         self._exchangeMessages()
 
         result = self.getInt()
@@ -421,6 +423,15 @@ class EncodedSession(session.Session):  # pylint: disable=too-many-public-method
         """Close the result set."""
         self._putMessageId(protocol.CLOSERESULTSET).putInt(resultset.handle)
         self._exchangeMessages(False)
+
+    def create_local_prepared_statement(self, query):
+        # type: (str) -> statement.PreparedStatement
+        """Create a local prepared statement for the given query."""
+        if self.__sessionVersion >= protocol.PREPARE_AND_EXECUTE_TOGETHER:
+            stmt = statement.PreparedStatement(-1, -1)
+            stmt.query = query
+            return stmt
+        return self.create_prepared_statement(query)
 
     def create_prepared_statement(self, query):
         # type: (str) -> statement.PreparedStatement
@@ -445,13 +456,21 @@ class EncodedSession(session.Session):  # pylint: disable=too-many-public-method
     ):
         # type: (...) -> statement.ExecutionResult
         """Execute a prepared statement with the given parameters."""
-        self._setup_statement(prepared_statement.handle, protocol.EXECUTEPREPAREDSTATEMENT)
+        if self.__sessionVersion >= protocol.PREPARE_AND_EXECUTE_TOGETHER and not self._isPrepared(prepared_statement):
+            self._setup_statement(prepared_statement, protocol.PREPAREANDEXECUTETOGETHER)
+        else:
+            self._setup_statement(prepared_statement, protocol.EXECUTEPREPAREDSTATEMENT)
 
         self.putInt(len(parameters))
         for param in parameters:
             self.putValue(param)
 
         self._exchangeMessages()
+
+        # Update handle and parameter count if needed
+        if self.__sessionVersion >= protocol.PREPARE_AND_EXECUTE_TOGETHER and not self._isPrepared(prepared_statement):
+            prepared_statement.handle = self.getInt()
+            prepared_statement.parameter_count = self.getInt()
 
         result = self.getInt()
         rowcount = self.getInt()
@@ -462,7 +481,7 @@ class EncodedSession(session.Session):  # pylint: disable=too-many-public-method
     def execute_batch_prepared_statement(self, prepared_statement, param_lists):
         # type: (statement.PreparedStatement, Collection[Collection[result_set.Value]]) -> List[int]
         """Batch the prepared statement with the given parameters."""
-        self._setup_statement(prepared_statement.handle, protocol.EXECUTEBATCHPREPAREDSTATEMENT)
+        self._setup_statement(prepared_statement, protocol.EXECUTEBATCHPREPAREDSTATEMENT)
 
         for parameters in param_lists:
             plen = len(parameters)
@@ -1317,14 +1336,26 @@ class EncodedSession(session.Session):  # pylint: disable=too-many-public-method
 
     # Protected utility routines
 
-    def _setup_statement(self, handle, msgId):
-        # type: (int, int) -> EncodedSession
+    def _setup_statement(self, prepared_statement, msgId):
+        # type: (statement.PreparedStatement, int) -> EncodedSession
         """Set up a new statement.
 
-        :type handle: int
+        :type prepared_statement: statement.PreparedStatement
         :type msgId: int
         """
+        if msgId != protocol.PREPAREANDEXECUTETOGETHER and not self._isPrepared(prepared_statement):
+            statement = self.create_prepared_statement(prepared_statement.query)
+            prepared_statement.handle = statement.handle
+            prepared_statement.parameter_count = statement.parameter_count
+
         self._putMessageId(msgId)
+
+        if msgId == protocol.PREPAREANDEXECUTETOGETHER:
+            self.putInt(protocol.DEFAULT_EXECUTE_SUBTYPE) #executeSubtype
+            self.putInt(protocol.DEFAULT_PREPARE_SUBTYPE) #prepareSubtype
+            self.putString(prepared_statement.query)
+            self.putInt(protocol.DEFAULT_EXECUTE_TIMEOUT_MS)  # timeout
+            self.putInt(protocol.DEFAULT_FETCH_SIZE)  # fetchsize
         if self.__sessionVersion >= protocol.LAST_COMMIT_INFO:
             with EncodedSession.__dblock:
                 self.putInt(len(self.__dbinfo))
@@ -1332,8 +1363,8 @@ class EncodedSession(session.Session):  # pylint: disable=too-many-public-method
                     self.putInt(sid)
                     self.putInt(tup[0])
                     self.putInt(tup[1])
-        self.putInt(handle)
-
+        if msgId != protocol.PREPAREANDEXECUTETOGETHER:
+            self.putInt(prepared_statement.handle)
         return self
 
     def _hasBytes(self, length):
@@ -1368,3 +1399,9 @@ class EncodedSession(session.Session):  # pylint: disable=too-many-public-method
             return self.__input[self.__inpos:self.__inpos + length]
         finally:
             self.__inpos += length
+    def _isPrepared(self,prepared_statement):
+        # type: (statement.PreparedStatement) -> bool
+        """Check if the prepared statement is valid."""
+        if prepared_statement.handle == -1:
+            return False
+        return True

--- a/pynuodb/protocol.py
+++ b/pynuodb/protocol.py
@@ -88,6 +88,7 @@ SETCURSORNAME                     = 21
 EXECUTEPREPAREDSTATEMENT          = 22
 EXECUTEPREPAREDQUERY              = 23
 EXECUTEPREPAREDUPDATE             = 24
+PREPAREANDEXECUTETOGETHER         = 25
 GETMETADATA                       = 26
 NEXT                              = 27
 CLOSERESULTSET                    = 28
@@ -343,6 +344,13 @@ def lookup_code(error_code):
     """Return a string-ified version of an error code."""
     return stringifyError.get(error_code, '[UNKNOWN ERROR CODE]')
 
+#
+# Default Options
+#
+DEFAULT_EXECUTE_TIMEOUT_MS = 0
+DEFAULT_FETCH_SIZE        = 0
+DEFAULT_EXECUTE_SUBTYPE   = 5
+DEFAULT_PREPARE_SUBTYPE  = 0
 
 #
 # NuoDB Client-Server Features
@@ -378,5 +386,5 @@ PREPARE_AND_EXECUTE_TOGETHER                    = 26
 # The newest feature this driver supports.
 # The server will negotiate the highest compatible version.
 CURRENT_PROTOCOL_MAJOR     = 1
-CURRENT_PROTOCOL_VERSION   = TIMESTAMP_WITHOUT_TZ
+CURRENT_PROTOCOL_VERSION   = PREPARE_AND_EXECUTE_TOGETHER
 AUTH_TEST_STR              = 'Success!'

--- a/pynuodb/statement.py
+++ b/pynuodb/statement.py
@@ -37,6 +37,7 @@ class PreparedStatement(Statement):
         super(PreparedStatement, self).__init__(handle)
         self.parameter_count = parameter_count
         self.description = None  # type: Optional[List[List[Any]]]
+        self.query = None  # type:  Optional[str]
 
 
 class ExecutionResult(object):

--- a/tests/nuodb_cursor_test.py
+++ b/tests/nuodb_cursor_test.py
@@ -7,7 +7,7 @@ See the LICENSE file provided with this software.
 
 import pytest
 
-from pynuodb.exception import DataError, ProgrammingError, BatchError, OperationalError
+from pynuodb.exception import DataError, ProgrammingError, BatchError, OperationalError, DatabaseError
 
 from . import nuodb_base
 
@@ -45,17 +45,17 @@ class TestNuoDBCursor(nuodb_base.NuoBase):
         con = self._connect()
         cursor = con.cursor()
 
-        with pytest.raises(ProgrammingError):
+        with pytest.raises(DatabaseError):
             cursor.execute("SELECT ?, ? FROM DUAL", [1])
 
     def test_toomany_parameters(self):
         con = self._connect()
         cursor = con.cursor()
 
-        with pytest.raises(ProgrammingError):
+        with pytest.raises(DatabaseError):
             cursor.execute("SELECT 1 FROM DUAL", [1])
 
-        with pytest.raises(ProgrammingError):
+        with pytest.raises(DatabaseError):
             cursor.execute("SELECT ? FROM DUAL", [1, 2])
 
     def test_incorrect_parameters(self):


### PR DESCRIPTION
Key Changes

1. Enhanced PreparedStatement to include the query string.
2. Refactored _setupStatement to use the full statement object instead of the handle.
3. Updated Cursor test case to expect a DatabaseError instead of a ProgrammingError — since prepare and execute are now performed together, errors are only identified from the response, which maps to a DatabaseError.
4. Introduced default values for prepare subtype, execute subtype, timeout, and fetch size in the protocol layer.