### PR TITLE
protocol.py: Add values for NuoDB 8.0 client protocol enhancements

### DIFF
--- a/pynuodb/connection.py
+++ b/pynuodb/connection.py
@@ -286,20 +286,20 @@ class Connection(object):
         """Returns a copy of the connection configuration.
 
         Configuration:
-          ap_host        :str:  Address of the AP host or None for direct
-          cipher         :str:  Name of the cipher if using SRP, else None
-          connected      :bool: True if the connection is active
-          connection_id  :int:  ID of the connection
-          db_name        :str:  name of the connected database
-          db_protocol_id :int:  Server protocol ID of the connected database
-          db_uuid        :uuid: UUID for the connected database
-          driver_version :str:  Version of this driver
-          engine_host    :str:  Address of the TE we're connected to
-          engine_id      :int:  ID for the TE we're connected to
-          options        :dict: Dictionary of connection options
-          protocol_id    :int:  Negotiated client protocol ID
-          tls_enabled    :bool: True if we're connected using TLS
-          user           :str:  name of the connected user
+          ap_host            :str:  Address of the AP host or None for direct
+          cipher             :str:  Name of the cipher if using SRP, else None
+          connected          :bool: True if the connection is active
+          connection_id      :int:  ID of the connection
+          db_name            :str:  name of the connected database
+          db_protocol_id     :int:  Server protocol ID of the connected database
+          db_uuid            :uuid: UUID for the connected database
+          driver_version     :str:  Version of this driver
+          engine_host        :str:  Address of the TE we're connected to
+          engine_id          :int:  ID for the TE we're connected to
+          options            :dict: Dictionary of connection options
+          client_protocol_id :int:  Negotiated client protocol ID
+          tls_enabled        :bool: True if we're connected using TLS
+          user               :str:  name of the connected user
 
         :returns: Copy of the connection config names and values.
                   Modifying these values has no effect on the connection.

--- a/pynuodb/protocol.py
+++ b/pynuodb/protocol.py
@@ -374,6 +374,8 @@ MULTI_CIPHER                                    = 23
 CURSOR_HOLDABILITY                              = 24
 TIMESTAMP_WITHOUT_TZ                            = 25
 PREPARE_AND_EXECUTE_TOGETHER                    = 26
+VECTOR_TYPE                                     = 27
+LAST_COMMIT_INFO_PREPARE                        = 28
 
 # The newest feature this driver supports.
 # The server will negotiate the highest compatible version.

--- a/tests/nuodb_types_test.py
+++ b/tests/nuodb_types_test.py
@@ -8,6 +8,8 @@ See the LICENSE file provided with this software.
 import decimal
 import datetime
 
+import pytest
+
 import pynuodb
 
 from . import nuodb_base
@@ -117,7 +119,6 @@ class TestNuoDBTypes(nuodb_base.NuoBase):
         assert row[2] == localize(datetime.datetime(2000, 1, 1, 5, 44, 33, 221100))
         assert localize(row[3]) == localize(datetime.datetime(2000, 1, 1, 5, 44, 33, 221100))
 
-
     def test_null_type(self):
         con = self._connect()
         cursor = con.cursor()
@@ -133,12 +134,13 @@ class TestNuoDBTypes(nuodb_base.NuoBase):
 
     def test_vector_type(self):
         con = self._connect()
+
+        # Skip this test if the client protocol doesn't support VECTOR_DOUBLE
+        cfg = con.connection_config()
+        if cfg['client_protocol_id'] < pynuodb.protocol.VECTOR_TYPE:
+            pytest.skip("VECTOR type is not supported")
+
         cursor = con.cursor()
-
-        # only activate this tests if tested against version 8 or above
-        if self.system_information['effective_version'] < 1835008:
-            return
-
         cursor.execute("CREATE TEMPORARY TABLE tmp ("
                        " vec3 VECTOR(3, DOUBLE),"
                        " vec5 VECTOR(5, DOUBLE))")


### PR DESCRIPTION
This does not actually implement these enhancements, we only make them known to the client code.

The nuodb_types_test is incorrectly using the server's effective version to fencepost tests: what we care about is whether the client protocol version that we negotiated with the server supports VECTOR, not whether the TE supports it.

Since we have not implemented VECTOR in the Python driver yet, this test will be skipped (rather than fail, as it was before).

Drive-by:
- Fix the docstring for connection.connection_config().