### PR TITLE
[DPY-24] Wrap import of typing in a try/except

### DIFF
--- a/pynuodb/calendar.py
+++ b/pynuodb/calendar.py
@@ -17,7 +17,11 @@ to map dates same as the calendar function in the nuodb server.  python
 datetime uses a proleptic Gregorian calendar.
 
 """
-from typing import Tuple  # pylint: disable=unused-import
+try:
+    from typing import Tuple  # pylint: disable=unused-import
+except ImportError:
+    pass
+
 import jdcal
 
 JD_EPOCH = sum(jdcal.gcal2jd(1970, 1, 1))

--- a/tests/mock_tzs.py
+++ b/tests/mock_tzs.py
@@ -8,11 +8,7 @@ See the LICENSE file provided with this software.
 
 from datetime import tzinfo, datetime
 import sys
-import typing
-import tzlocal
 import pytz
-from pynuodb.datatype import LOCALZONE_NAME
-
 
 try:
     from zoneinfo import ZoneInfo
@@ -20,14 +16,20 @@ try:
 except ImportError:
     HAS_ZONEINFO = False
 
-# Define a type for mypy/static typing
-if typing.TYPE_CHECKING:
-    if sys.version_info >= (3, 9):
-        from zoneinfo import ZoneInfo as TZType
+try:
+    import typing
+    # Define a type for mypy/static typing
+    if typing.TYPE_CHECKING:
+        if HAS_ZONEINFO:
+            TZType = ZoneInfo
+        else:
+            from pytz.tzinfo import BaseTzInfo as TZType
     else:
-        from pytz.tzinfo import BaseTzInfo as TZType
-else:
-    TZType = tzinfo
+        TZType = tzinfo
+except ImportError:
+    pass
+
+from pynuodb.datatype import LOCALZONE_NAME
 
 
 # Timezone getter function


### PR DESCRIPTION
In Python2 the typing module is not available by default and we don't add it as a prerequisite since it's only needed for type checking.

However some recent changes forgot to wrap the import of typing in a try/except block to catch and ignore the ImportError exception.